### PR TITLE
change endl in the output to \n have great effect on the performance

### DIFF
--- a/utils/dsk2ascii.cpp
+++ b/utils/dsk2ascii.cpp
@@ -70,7 +70,7 @@ public:
         for (itKmers->first(); !itKmers->isDone(); itKmers->next())
         {
             const Count& count = itKmers->item();
-            output << model.toString(count.value) << " " << count.abundance << endl;
+            output << model.toString(count.value) << " " << count.abundance << "\n";
         }
 
         output.close();


### PR DESCRIPTION
Hello,
dsk2ascii tool takes an unjustifiably long time to dump the kmers and counts to the text format. I noticed that "endl" is used to output a new line which is not efficient for huge output files because it forces the operating system to flush the output buffer after each kmer. Instead, I replaced the "endl" with "\n" and it reduces the running time on my laptop from 4:30 mins to 40 seconds. 


Have a nice day,
Mostafa
